### PR TITLE
feat(CG-1293): add GCP CIS 1.30 1.16 rule

### DIFF
--- a/src/gcp/cis-1.3.0/README.md
+++ b/src/gcp/cis-1.3.0/README.md
@@ -70,6 +70,7 @@ Policy Pack based on the GCP Foundations 1.3.0 benchmark provided by the [Center
 | GCP CIS 1.13   | Ensure API keys are restricted to use by only specified Hosts and Apps                                                                                              |
 | GCP CIS 1.14   | Ensure API keys are restricted to only APIs that application needs access                                                                                           |
 | GCP CIS 1.15   | Ensure API keys are rotated every 90 days                                                                                                                           |
+| GCP CIS 1.16   | Ensure Essential Contacts is Configured for Organization                                                                                                            |
 | GCP CIS 2.1    | Ensure that Cloud Audit Logging is configured properly across all services and all users from a project                                                             |
 | GCP CIS 2.2    | Ensure that sinks are configured for all log entries                                                                                                                |
 | GCP CIS 2.3    | Ensure that retention policies on log buckets are configured using Bucket Lock                                                                                      |

--- a/src/gcp/cis-1.3.0/rules/gcp-cis-1.3.0-1.16.ts
+++ b/src/gcp/cis-1.3.0/rules/gcp-cis-1.3.0-1.16.ts
@@ -78,15 +78,20 @@ export default {
       email
     }
   }`,
-  resource: 'querygcpEssentialContact[1]',
+  resource: 'querygcpProject[*]',
   severity: 'unknown',
 
-  check: ({ data }: any): boolean => {
+  check: ({ resource }: any): boolean => {
+    const { essentialContacts } = resource
+    
+    if (!essentialContacts || essentialContacts.length === 0) {
+      return false
+    }
+
     const requiredCategories = ['LEGAL', 'SECURITY', 'SUSPENSION', 'TECHNICAL', 'TECHNICAL_INCIDENTS']
     const categoryAll = 'ALL'
 
-    const subscribedCategories = data.querygcpEssentialContact
-      .filter((obj: any) => !('@' in obj))
+    const subscribedCategories = essentialContacts
       .flatMap(({notificationCategorySubscriptions}: any) => notificationCategorySubscriptions)
       
     const result = requiredCategories.every((category: any) => subscribedCategories.includes(category))

--- a/src/gcp/cis-1.3.0/rules/gcp-cis-1.3.0-1.16.ts
+++ b/src/gcp/cis-1.3.0/rules/gcp-cis-1.3.0-1.16.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export default {
+  id: 'gcp-cis-1.3.0-1.16',
+  title: 'GCP CIS 1.16 Ensure Essential Contacts is Configured for Organization',
+  description:
+    'It is recommended that Essential Contacts is configured to designate email addresses for Google Cloud services to notify of important technical or security information.',
+  audit: `**From Console:**
+  
+  1. Go to Essential Contacts by visiting https://console.cloud.google.com/iam-admin/essential-contacts
+  2. Make sure the organization appears in the resource selector at the top of the page. The resource selector tells you what project, folder, or organization you are currently managing contacts for.
+  3. Ensure that appropriate email addresses are configured for each of the following notification categories:
+
+    - Legal
+    - Security
+    - Suspension
+    - Technical
+    - Technical Incidents
+  
+  Alternatively, appropriate email addresses can be configured for the All notification category to receive all possible important notifications.
+
+  **From Command Line:**
+
+  1. To list all configured organization Essential Contacts run a command:
+
+          gcloud essential-contacts list --organization=<ORGANIZATION_ID>
+
+  2. Ensure at least one appropriate email address is configured for each of the following notification categories:
+
+    - LEGAL
+    - SECURITY
+    - SUSPENSION
+    - TECHNICAL
+    - TECHNICAL_INCIDENTS
+  
+  Alternatively, appropriate email addresses can be configured for the ALL notification category to receive all possible important notifications.
+  `,
+  rationale:
+    'Many Google Cloud services, such as Cloud Billing, send out notifications to share important information with Google Cloud users. By default, these notifications are sent to members with certain Identity and Access Management (IAM) roles. With Essential Contacts, you can customize who receives notifications by providing your own list of contacts.',
+  remediation: `**From Console:**
+  1. Go to Essential Contacts by visiting https://console.cloud.google.com/iam-admin/essential-contacts
+  2. Make sure the organization appears in the resource selector at the top of the page. The resource selector tells you what project, folder, or organization you are currently managing contacts for.
+  3. Click +Add contact
+  4. In the Email and Confirm Email fields, enter the email address of the contact.
+  5. From the Notification categories drop-down menu, select the notification categories that you want the contact to receive communications for.
+  6. Click Save
+
+  **From Command Line:**
+
+  1. To add an organization Essential Contacts run a command:
+
+          gcloud essential-contacts create --email="<EMAIL>" \
+          --notification-categories="<NOTIFICATION_CATEGORIES>" \
+          --organization=<ORGANIZATION_ID>
+
+  **Default Value:**
+
+    By default, there are no Essential Contacts configured.
+
+    In the absence of an Essential Contact, the following IAM roles are used to identify users to
+    notify for the following categories:
+
+      • Legal: roles/billing.admin
+      • Security: roles/resourcemanager.organizationAdmin
+      • Suspension: roles/owner
+      • Technical: roles/owner
+      • Technical Incidents: roles/owner
+  `,
+  references: [
+    'https://cloud.google.com/resource-manager/docs/managing-notification-contacts',
+  ],
+  gql: `{
+    querygcpEssentialContact {
+      id
+      __typename
+      notificationCategorySubscriptions
+      email
+    }
+  }`,
+  resource: 'querygcpEssentialContact[1]',
+  severity: 'unknown',
+
+  check: ({ data }: any): boolean => {
+    const requiredCategories = ['LEGAL', 'SECURITY', 'SUSPENSION', 'TECHNICAL', 'TECHNICAL_INCIDENTS']
+    const categoryAll = 'ALL'
+
+    const subscribedCategories = data.querygcpEssentialContact
+      .filter((obj: any) => !('@' in obj))
+      .flatMap(({notificationCategorySubscriptions}: any) => notificationCategorySubscriptions)
+      
+    const result = requiredCategories.every((category: any) => subscribedCategories.includes(category))
+
+    return result || subscribedCategories.includes(categoryAll)
+  }
+}

--- a/src/gcp/cis-1.3.0/rules/index.ts
+++ b/src/gcp/cis-1.3.0/rules/index.ts
@@ -13,6 +13,7 @@ import Gcp_CIS_130_112 from './gcp-cis-1.3.0-1.12'
 import Gcp_CIS_130_113 from './gcp-cis-1.3.0-1.13'
 import Gcp_CIS_130_114 from './gcp-cis-1.3.0-1.14'
 import Gcp_CIS_130_115 from './gcp-cis-1.3.0-1.15'
+import Gcp_CIS_130_116 from './gcp-cis-1.3.0-1.16'
 import Gcp_CIS_130_21 from './gcp-cis-1.3.0-2.1'
 import Gcp_CIS_130_22 from './gcp-cis-1.3.0-2.2'
 import Gcp_CIS_130_23 from './gcp-cis-1.3.0-2.3'
@@ -89,6 +90,7 @@ export default [
   Gcp_CIS_130_113,
   Gcp_CIS_130_114,
   Gcp_CIS_130_115,
+  Gcp_CIS_130_116,
   Gcp_CIS_130_21,
   Gcp_CIS_130_22,
   Gcp_CIS_130_23,

--- a/src/gcp/cis-1.3.0/tests/gcp-cis-1.3.0-1.x.test.ts
+++ b/src/gcp/cis-1.3.0/tests/gcp-cis-1.3.0-1.x.test.ts
@@ -32,6 +32,11 @@ export interface IamPolicy {
 export interface ApiKey {
   id: string
 }
+export interface EssentialContact {
+  id: string
+  notificationCategorySubscriptions: string[]
+  email: string
+}
 export interface Folder {
   iamPolicies: IamPolicy[]
 }
@@ -82,6 +87,7 @@ export interface QuerygcpProject {
   id: string
   iamPolicies?: IamPolicy[]
   apiKeys?: ApiKey[]
+  essentialContacts?: EssentialContact[]
 }
 
 export interface QuerygcpServiceAccount {
@@ -105,11 +111,6 @@ export interface QuerygcpIamPolicy {
   bindings: Bindings[]
 }
 
-export interface QuerygcpEssentialContact {
-  id: string
-  notificationCategorySubscriptions: string[]
-  email: string
-}
 export interface CIS1xQueryResponse {
   querygcpOrganization?: QuerygcpOrganization[]
   querygcpProject?: QuerygcpProject[]
@@ -117,7 +118,6 @@ export interface CIS1xQueryResponse {
   querygcpServiceAccount?: QuerygcpServiceAccount[]
   querygcpKmsKeyRing?: QuerygcpKmsKeyRing[]
   querygcpIamPolicy?: QuerygcpIamPolicy[]
-  querygcpEssentialContact?: QuerygcpEssentialContact[]
 }
 
 describe('CIS Google Cloud Platform Foundations: 1.3.0', () => {
@@ -905,56 +905,84 @@ describe('CIS Google Cloud Platform Foundations: 1.3.0', () => {
       expect(processedRule.result).toBe(expectedResult)
     }
 
-    test('Emails subscribed all required categories', async () => {
+    test('No Security Issue when Emails subscribed all required categories', async () => {
       const data: CIS1xQueryResponse = {
-        querygcpEssentialContact: [
+        querygcpProject: [
           {
             id: cuid(),
-            notificationCategorySubscriptions: ['LEGAL', 'TECHNICAL', 'SUSPENSION', 'SECURITY'],
-            email: 'a@gmail.com'
-          },
-          {
-            id: cuid(),
-            notificationCategorySubscriptions: ['TECHNICAL_INCIDENTS', 'SECURITY', 'BILLING'],
-            email: 'b@gmail.com'
+            essentialContacts: [
+              {
+                id: cuid(),
+                notificationCategorySubscriptions: ['LEGAL', 'TECHNICAL', 'SUSPENSION', 'SECURITY'],
+                email: 'a@gmail.com'
+              },
+              {
+                id: cuid(),
+                notificationCategorySubscriptions: ['TECHNICAL_INCIDENTS', 'SECURITY', 'BILLING'],
+                email: 'b@gmail.com'
+              },
+            ],
           },
         ],
       }
       await testRule(data, Result.PASS)
     })
-    test('Emails missed one required subscription category', async () => {
+    test('Security Issue when Emails missed one required subscription category', async () => {
       const data: CIS1xQueryResponse = {
-        querygcpEssentialContact: [
-          {
-            id: cuid(),
-            notificationCategorySubscriptions: ['LEGAL', 'SUSPENSION', 'SECURITY'],
-            email: 'a@gmail.com'
-          },
-          {
-            id: cuid(),
-            notificationCategorySubscriptions: ['TECHNICAL_INCIDENTS', 'SECURITY', 'BILLING'],
-            email: 'b@gmail.com'
-          },
-        ],
+        querygcpProject: [{
+          id: cuid(),
+          essentialContacts: [
+            {
+              id: cuid(),
+              notificationCategorySubscriptions: ['LEGAL', 'SUSPENSION', 'SECURITY'],
+              email: 'a@gmail.com'
+            },
+            {
+              id: cuid(),
+              notificationCategorySubscriptions: ['TECHNICAL_INCIDENTS', 'SECURITY', 'BILLING'],
+              email: 'b@gmail.com'
+            },
+          ],
+        }]
       }
       await testRule(data, Result.FAIL)
     })
-    test('An email subscribed ALL category', async () => {
+    test('No Security Issue when an email subscribed ALL category', async () => {
       const data: CIS1xQueryResponse = {
-        querygcpEssentialContact: [
-          {
-            id: cuid(),
-            notificationCategorySubscriptions: ['LEGAL', 'TECHNICAL', 'SUSPENSION', 'SECURITY'],
-            email: 'a@gmail.com'
-          },
-          {
-            id: cuid(),
-            notificationCategorySubscriptions: ['ALL'],
-            email: 'b@gmail.com'
-          },
-        ],
+        querygcpProject: [{
+          id: cuid(),
+          essentialContacts: [
+            {
+              id: cuid(),
+              notificationCategorySubscriptions: ['LEGAL', 'TECHNICAL', 'SUSPENSION', 'SECURITY'],
+              email: 'a@gmail.com'
+            },
+            {
+              id: cuid(),
+              notificationCategorySubscriptions: ['ALL'],
+              email: 'b@gmail.com'
+            },
+          ],
+        }]
       }
       await testRule(data, Result.PASS)
+    })
+    test('Security Issue when Essential contact API is not enabled', async () => {
+      const data: CIS1xQueryResponse = {
+        querygcpProject: [{
+          id: cuid(),
+        }]
+      }
+      await testRule(data, Result.FAIL)
+    })
+    test('Security Issue when Essential contact is either not configured', async () => {
+      const data: CIS1xQueryResponse = {
+        querygcpProject: [{
+          id: cuid(),
+          essentialContacts: [],
+        }]
+      }
+      await testRule(data, Result.FAIL)
     })
   })
 })


### PR DESCRIPTION
A known possible issue with the rule checker is: due to the `resource: 'querygcpEssentialContact[1]'`. If the query returns an empty array or undefined. The checker would never called and the `rulesEngine.processRule` would return `undefined`.
Any idea to handle this case?